### PR TITLE
add optional custom config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ The reasons why template rendering can fail:
 
 The CLI tries to validate as much as possible but it's still recommended to set up a recovery mechanism for the rendering failures.
 
+## User configuration file
+
+An optional user configuration file can be placed at `${HOME}/.newsletter-cli/config.js`, which allows certain customizations. The [sample user configuration](user-config.sample.js) is commented with the possible customizations.
+
 ## Get Help
 
 [Open an issue](https://github.com/orkon/newsletter-cli/issues)

--- a/src/lib/Newsletter.ts
+++ b/src/lib/Newsletter.ts
@@ -4,19 +4,19 @@ import juice = require("juice");
 import * as marked from "marked";
 import rmm = require("remove-markdown");
 import { UserConfig } from "./UserConfig";
-const userConfigObj: UserConfig = new UserConfig();
-const userConfig: any = userConfigObj.load();
 
 type FrontMatter = typeof fm.default;
 
 export class Newsletter {
   private name: string;
   private filePath: string;
+  private userConfig: UserConfig;
 
-  constructor(name: string) {
+  constructor(name: string, userConfig: UserConfig) {
     this.validateName(name);
     this.name = name;
     this.filePath = this.resolveFilePath(name);
+    this.userConfig = userConfig;
   }
 
   public exists() {
@@ -49,9 +49,12 @@ export class Newsletter {
   }
 
   public writeTemplate() {
-    const subject = userConfig.template_subject ? userConfig.template_subject : "Subject of your awesome newsletter!";
-    const styles = userConfig.template_css ? userConfig.template_css : require.resolve("github-markdown-css");
-    const body = userConfig.template_body ? userConfig.template_body : `Hi {{name}}!
+    const templateSubject = this.userConfig.getTemplateSubject();
+    const templateCss = this.userConfig.getTemplateCss();
+    const templateBody = this.userConfig.getTemplateBody();
+    const subject = templateSubject ? templateSubject : "Subject of your awesome newsletter!";
+    const styles = templateCss ? templateCss : require.resolve("github-markdown-css");
+    const body = templateBody ? templateBody : `Hi {{name}}!
 
 Here goes the text of your awesome newsletter!`;
 

--- a/src/lib/Newsletter.ts
+++ b/src/lib/Newsletter.ts
@@ -3,6 +3,9 @@ import * as fs from "fs";
 import juice = require("juice");
 import * as marked from "marked";
 import rmm = require("remove-markdown");
+import { UserConfig } from "./UserConfig";
+const userConfigObj: UserConfig = new UserConfig();
+const userConfig: any = userConfigObj.load();
 
 type FrontMatter = typeof fm.default;
 
@@ -46,16 +49,20 @@ export class Newsletter {
   }
 
   public writeTemplate() {
+    const subject = userConfig.template_subject ? userConfig.template_subject : "Subject of your awesome newsletter!";
+    const styles = userConfig.template_css ? userConfig.template_css : require.resolve("github-markdown-css");
+    const body = userConfig.template_body ? userConfig.template_body : `Hi {{name}}!
+
+Here goes the text of your awesome newsletter!`;
+
     fs.writeFileSync(
       this.filePath,
       `---
-subject: Subject of your awesome newsletter!
-styles: ${require.resolve("github-markdown-css")}
+subject: ${subject}
+styles: ${styles}
 ---
 
-Hi {{name}}!
-
-Here goes the text of your awesome newsletter!
+${body}
 `,
       "utf8",
     );

--- a/src/lib/UserConfig.ts
+++ b/src/lib/UserConfig.ts
@@ -4,13 +4,56 @@ import os = require("os");
 const homedir = os.homedir();
 const configModule = `${homedir}/.newsletter-cli/config`;
 
+export type Config = {
+  template_subject?: unknown
+  template_css?: unknown
+  template_body?: unknown
+  source_default?: unknown
+  ses_send_configuration?: unknown
+}
+
 export class UserConfig {
-  public load() {
-    let config = {};
+  private _config: Config;
+  constructor() {
+    this._config = {};
     if (fs.existsSync(`${configModule}.js`)) {
       // tslint:disable:no-var-requires
-      config = require(configModule);
+      this._config = require(configModule);
     }
-    return config;
   }
-}
+  getTemplateSubject(): string | undefined {
+    const templateSubject = this._config.template_subject as string | undefined;
+    if (typeof templateSubject !== 'undefined' && typeof templateSubject !== 'string') {
+       throw new Error("template_subject must be a string")
+    }
+    return templateSubject;
+  }
+  getTemplateCss(): string | undefined {
+    const templateCss = this._config.template_css as string | undefined;
+    if (typeof templateCss !== 'undefined' && templateCss && typeof templateCss !== 'string') {
+       throw new Error("template_css must be a string")
+    }
+    return templateCss;
+  }
+  getTemplateBody(): string | undefined {
+    const templateBody = this._config.template_body as string | undefined;
+    if (typeof templateBody !== 'undefined' && typeof templateBody !== 'string') {
+       throw new Error("template_body must be a string")
+    }
+    return templateBody;
+  }
+  getSourceDefault(): string | undefined {
+    const sourceDefault = this._config.source_default as string | undefined;
+    if (typeof sourceDefault !== 'undefined' && typeof sourceDefault !== 'string') {
+       throw new Error("source_default must be a string")
+    }
+    return sourceDefault;
+  }
+  getSesSendConfiguration(): object | undefined {
+    const sesSendConfiguration = this._config.ses_send_configuration as object | undefined;
+    if (typeof sesSendConfiguration !== 'undefined' && typeof sesSendConfiguration !== 'object') {
+       throw new Error("ses_send_configuration must be an object")
+    }
+    return sesSendConfiguration;
+  }
+};

--- a/src/lib/UserConfig.ts
+++ b/src/lib/UserConfig.ts
@@ -1,0 +1,16 @@
+import fs = require("fs");
+import os = require("os");
+
+const homedir = os.homedir();
+const configModule = `${homedir}/.newsletter-cli/config`;
+
+export class UserConfig {
+  public load() {
+    let config = {};
+    if (fs.existsSync(`${configModule}.js`)) {
+      // tslint:disable:no-var-requires
+      config = require(configModule);
+    }
+    return config;
+  }
+}

--- a/src/lib/commands/ExistingNewsletterCommand.ts
+++ b/src/lib/commands/ExistingNewsletterCommand.ts
@@ -1,9 +1,10 @@
 import { Newsletter } from "../Newsletter";
+import {UserConfig} from "../UserConfig";
 
 export class ExistingNewsLetterCommand {
   protected newsletter: Newsletter;
-  constructor(name: string) {
-    this.newsletter = new Newsletter(name);
+  constructor(name: string, userConfig: UserConfig) {
+    this.newsletter = new Newsletter(name, userConfig);
     if (!this.newsletter.exists()) {
       throw new Error(
         `Newsletter with name ${this.newsletter.getName()} does not exist`,

--- a/src/lib/commands/PrepareCommand.ts
+++ b/src/lib/commands/PrepareCommand.ts
@@ -1,8 +1,14 @@
 import * as chalk from "chalk";
 import * as inquirer from "inquirer";
 import { Newsletter } from "../Newsletter";
+import {UserConfig} from "../UserConfig";
 
 export class PrepareCommand {
+  private userConfig: UserConfig;
+
+  constructor(userConfig: UserConfig) {
+    this.userConfig = userConfig;
+  }
   public async run() {
     const question: inquirer.Question<IAnswer> = {
       default: "NEWSLETTER_NAME",
@@ -13,7 +19,7 @@ export class PrepareCommand {
       validate: () => true,
     };
     const { name } = await inquirer.prompt([question]);
-    const newsletter = new Newsletter(name);
+    const newsletter = new Newsletter(name, this.userConfig);
     if (newsletter.exists()) {
       throw new Error(
         `Newsletter with name ${newsletter.getFilePath()} already exists`,

--- a/src/lib/commands/SendCommand.ts
+++ b/src/lib/commands/SendCommand.ts
@@ -6,6 +6,7 @@ import * as Ora from "ora";
 import { Recipients } from "../Recipients";
 import { Sender } from "../Sender";
 import { SesTransport } from "../SesTransport";
+import {UserConfig} from "../UserConfig";
 import { ExistingNewsLetterCommand } from "./ExistingNewsletterCommand";
 
 export class SendCommand extends ExistingNewsLetterCommand {
@@ -14,10 +15,10 @@ export class SendCommand extends ExistingNewsLetterCommand {
   private source: string;
   private recipientsCsv: string;
 
-  constructor(name: string, recipientsCsv: string, source: string) {
-    super(name);
+  constructor(name: string, recipientsCsv: string, source: string, userConfig: UserConfig) {
+    super(name, userConfig);
     this.recipientsCsv = recipientsCsv;
-    this.sender = new Sender(this.newsletter, new SesTransport());
+    this.sender = new Sender(this.newsletter, new SesTransport(userConfig));
     this.recipients = new Recipients(this.readCsvFile());
     this.source = source;
     this.validateSource();

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,6 +4,8 @@ import { EditCommand } from "./commands/EditCommand";
 import { PrepareCommand } from "./commands/PrepareCommand";
 import { PreviewCommand } from "./commands/PreviewCommand";
 import { SendCommand } from "./commands/SendCommand";
+import { UserConfig } from "./UserConfig";
+const userConfigObj: UserConfig = new UserConfig();
 
 export async function run() {
   const [, , command, name, recipientsCsv, source] = process.argv;
@@ -25,10 +27,12 @@ export async function run() {
         break;
 
       case "send":
+        const userConfig: any = userConfigObj.load();
+        const sourceWithFallback = source || userConfig.source_default;
         requireName(name);
         requireRecipientsCsv(recipientsCsv);
-        requireSource(source);
-        await new SendCommand(name, recipientsCsv, source).run();
+        requireSource(sourceWithFallback);
+        await new SendCommand(name, recipientsCsv, sourceWithFallback).run();
         break;
 
       case "help":

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -13,26 +13,28 @@ export async function run() {
   try {
     switch (command) {
       case "prepare":
-        await new PrepareCommand().run();
+        await new PrepareCommand(userConfigObj).run();
         break;
 
       case "preview":
         requireName(name);
-        await new PreviewCommand(name).run();
+        await new PreviewCommand(name, userConfigObj).run();
         break;
 
       case "edit":
         requireName(name);
-        await new EditCommand(name).run();
+        await new EditCommand(name, userConfigObj).run();
         break;
 
       case "send":
-        const userConfig: any = userConfigObj.load();
-        const sourceWithFallback = source || userConfig.source_default;
+        let sourceWithFallback = source;
+        if (!sourceWithFallback) {
+          sourceWithFallback = userConfigObj.getSourceDefault()!;
+        }
         requireName(name);
         requireRecipientsCsv(recipientsCsv);
         requireSource(sourceWithFallback);
-        await new SendCommand(name, recipientsCsv, sourceWithFallback).run();
+        await new SendCommand(name, recipientsCsv, sourceWithFallback, userConfigObj).run();
         break;
 
       case "help":

--- a/user-config.sample.js
+++ b/user-config.sample.js
@@ -24,6 +24,14 @@ config.template_body = template_data;
 // Default source email.
 config.source_default = "noreply@example.com"
 
+/**
+ * These customizations alter the SES transport.
+ */
+// Merge into request object for sending.
+config.ses_send_configuration = {
+  ConfigurationSetName: "bulk-send",
+}
+
 /***** END *****/
 // Following lines are always needed.
 var module = module || {};

--- a/user-config.sample.js
+++ b/user-config.sample.js
@@ -1,0 +1,32 @@
+const fs = require("fs");
+const homedir = require("os").homedir();
+
+const config_dir = `${homedir}/.newsletter-cli`;
+const template_path = `${config_dir}/base_template.html`;
+const style_path = `${config_dir}/style.css`;
+const template_data = fs.readFileSync(template_path, {encoding:'utf8', flag:'r'}).toString();
+
+const config = {}
+
+/**
+ * These customizations alter the output of the 'prepare' command.
+ */
+// Custom subject.
+config.template_subject = "My custom subject line"
+// Custom CSS style path.
+config.template_css = style_path
+// Custom body.
+config.template_body = template_data;
+
+/**
+ * These customizations alter the output of the 'send' command.
+ */
+// Default source email.
+config.source_default = "noreply@example.com"
+
+/***** END *****/
+// Following lines are always needed.
+var module = module || {};
+module.exports = config;
+
+// vi: ft=javascript


### PR DESCRIPTION
This adds the option for a user to write a `${HOME}/.newsletter-cli.js`
config file, which, at the moment, allows customizing the subject,
styles, and body of the generated template.

My JS skills are pretty good, but I've never written a line of TypeScript before -- not totally sure I got all the syntax the best it can be, particularly the conditional include of the user config file.

Also not 100% sure about the names I used in the config file. Perhaps better namespacing like this?

```javascript
const config = {}
config.template = {}
config.template.subject = "SYSTEM NOTIFICATION -- "
config.template.css = "./style.css"
config.template.body = "stuff"
```
Also maybe `${HOME}/.newsletter-cli/config.js` instead of `${HOME}/.newsletter-cli.js`? That would give a reasonable place to stick the custom `style.css` too...

Happy to make adjustments to my PR. Thanks for this project, it's much nicer than the hack I've been using.