### PR TITLE
add 'npm run cli'

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "test": "jest",
+    "cli": "node dist/index.js",
     "prepublishOnly": "npm run lint && npm run depcheck && npm run compile",
     "compile": "npm run clean && tsc -p .",
     "watch": "tsc -w -p .",


### PR DESCRIPTION
Adds a 'cli' param to the npm scripts, for easy execution
of the compiled code.

I'm not sure if this is actually the best way to do things with the TypeScript compiling, if there's some better way I'd love to hear it.