### PR TITLE
allow email addresses with labels

### DIFF
--- a/src/lib/commands/SendCommand.ts
+++ b/src/lib/commands/SendCommand.ts
@@ -9,6 +9,15 @@ import { SesTransport } from "../SesTransport";
 import { ExistingNewsLetterCommand } from "./ExistingNewsletterCommand";
 
 export class SendCommand extends ExistingNewsLetterCommand {
+
+  public static extractEmail(email: string) : string {
+    const emailMatcher = new RegExp("^.*<(.+)>$");
+    const parts = email.match(emailMatcher);
+    if (parts) {
+      email = parts[1];
+    }
+    return email;
+  }
   private sender: Sender;
   private recipients: Recipients;
   private source: string;
@@ -79,8 +88,9 @@ export class SendCommand extends ExistingNewsLetterCommand {
   }
 
   private validateSource() {
-    if (!ismail.validate(this.source)) {
-      throw new Error(`Sender's email address "${this.source}: is not valid`);
+    const email = SendCommand.extractEmail(this.source);
+    if (!ismail.validate(email)) {
+      throw new Error(`Sender's email address "${email}: is not valid`);
     }
   }
 

--- a/src/test/lib/commands/SendCommand.test.ts
+++ b/src/test/lib/commands/SendCommand.test.ts
@@ -1,0 +1,9 @@
+import { SendCommand } from "../../../lib/commands/SendCommand";
+
+test("should extract email address when only email address provided", () => {
+  expect(SendCommand.extractEmail("a@b.com")).toEqual("a@b.com");
+});
+
+test("should extract email address only when full address provided", () => {
+  expect(SendCommand.extractEmail(`"AB" <a@b.com>`)).toEqual("a@b.com");
+});


### PR DESCRIPTION
This adds a simple extractEmail() method, which conditionally pulls only
the email address from a bracket expression for purposes of validation.

The regex for the extraction is left deliberately simple, it does not
attempt to do any validation